### PR TITLE
:bug: fix not being fully signed in on search pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-bing-rewards",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Automated runner for Bing / Microsoft Rewards",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ms-rewards.ts
+++ b/src/ms-rewards.ts
@@ -47,11 +47,29 @@ export async function login(browser: puppeteer.Browser) {
 
 export async function runSearch(browser: puppeteer.Browser, text: string) {
   const searchPage = await browser.newPage();
+
   await searchPage.goto('https://bing.com/');
+
+  // Check if log in carried over
+  await searchPage.evaluate(async () => {
+    const signInAnchor: HTMLAnchorElement = document.querySelector('#id_l');
+    const loggedInUsername = signInAnchor.textContent;
+    const signedOut = loggedInUsername.toLocaleLowerCase() === 'sign in';
+
+    if (!signedOut) return signedOut;
+
+    // Click sign in if necessary
+    signInAnchor.click();
+
+    // HACK: Wait arbitrary time for cookies to be loaded.
+    return new Promise(resolve => setTimeout(resolve, 1000));
+  });
+
   await searchPage.type('[name="q"]', text, { delay: 26 });
   const formHandle = await searchPage.$('#sb_form');
   await formHandle.press('Enter');
   await searchPage.waitForNavigation();
   await searchPage.waitFor(randomInt(2000, 5000));
+
   await searchPage.close();
 }


### PR DESCRIPTION
Even though an account could be logged in and the necessary cookies exist on the page, the search pages would default to keeping the user signed out. This changes that to click "Sign in" if necessary.